### PR TITLE
Update Fan Pin Link to Bigtreetech repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 # BTT-PI FAN Pin 
 
 ***BIGTREETECH Pi V1.2 Fan Pin connection
-Please refer to [here](https://github.com/So6Rallye/BTT-Pi/blob/master/BIGTREETECH%20Pi%20V1.2%20-%20Board%20Fan%20Pin%20Configuration) for details***
+Please refer to [here](https://github.com/bigtreetech/BTT-Pi/blob/master/BIGTREETECH%20Pi%20V1.2%20-%20Board%20Fan%20Pin%20Configuration) for details***


### PR DESCRIPTION
The past commit links to a user fork of this repo. Changed the link to keep everything in the official Bigtreetech repo.